### PR TITLE
Temporary fix to lecture 41

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1888,13 +1888,12 @@
       }
     },
     "@middy/validator": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@middy/validator/-/validator-1.3.0.tgz",
-      "integrity": "sha512-Nyxh5dqMv8VCfwywgexB4Y3UJCZMP054pHtag8fBzJ4Mx5XUhrbAS1LorFI1lTHIEdbPs/BCsL09QaLPN/wLZg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@middy/validator/-/validator-1.2.0.tgz",
+      "integrity": "sha512-QJivzMoohLM7un4e5Q1trctWPD7gxnjyA6+aP7xJgEQO3Rmb6uBwKxFbRrkv4PJJxQq+TAV3tiCnEROVofbmZg==",
       "requires": {
         "@types/http-errors": "^1.6.1",
         "ajv": "^6.5.0",
-        "ajv-errors": "^1.0.1",
         "ajv-i18n": "^3.3.0",
         "ajv-keywords": "^3.2.0",
         "http-errors": "^1.6.3"
@@ -2372,7 +2371,8 @@
     "ajv-errors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
-      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
+      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
+      "dev": true
     },
     "ajv-i18n": {
       "version": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@middy/http-error-handler": "^1.2.0",
     "@middy/http-event-normalizer": "^1.2.0",
     "@middy/http-json-body-parser": "^1.2.0",
-    "@middy/validator": "^1.3.0",
+    "@middy/validator": "^1.2.0",
     "@types/aws-lambda": "^8.10.61",
     "aws-sdk": "^2.734.0",
     "http-errors": "^1.8.0",


### PR DESCRIPTION
Seems like the latest version, 1.3.0 (that was added by package author of @middy a day back) has issues ... thus I changed to one version back, 1.2.0

1. Uninstall these packages

```
npm uninstall \
@middy/core \
@middy/http-error-handler \
@middy/http-event-normalizer \
@middy/http-json-body-parser \
@middy/validator
```

 2. Install back these packages (1.2.0)

```
npm install \
@middy/core@1.2.0 \
@middy/http-error-handler@1.2.0 \
@middy/http-event-normalizer@1.2.0 \
@middy/http-json-body-parser@1.2.0 \
@middy/validator@1.2.0
```